### PR TITLE
HOME env var in initscript

### DIFF
--- a/templates/javainitscript.erb
+++ b/templates/javainitscript.erb
@@ -21,7 +21,8 @@
  
 # Set this to your Java installation
 JAVA_HOME=<%=java_home%>
- 
+HOME=<%=serviceuserhome%> 
+
 serviceNameLo="<%= servicename.downcase %>"	     # service name with the first letter in lowercase
 serviceName="<%= servicename %>"                     # service name
 serviceUser="<%= serviceuser %>"                     # OS user name for the service


### PR DESCRIPTION
Logstash init script does not set the HOME env variable and does not start correctly because of that.

Adding HOME env to the init script fixes the error.
