### PR TITLE
Add the ability to set a custom indexer template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,7 +40,8 @@ class logstash::config( $logstash_home = '/usr/local/logstash',
   $redis_key = 'logstash',
   $java_provider = 'package',
   $java_package = 'java-1.6.0-openjdk',
-  $java_home = '/usr/lib/jvm/jre-1.6.0-openjdk.x86_64'
+  $java_home = '/usr/lib/jvm/jre-1.6.0-openjdk.x86_64',
+  $indexer_template = undef
 ) {
 
   # just trying to make the fq variable a little less rediculous

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -31,18 +31,21 @@ class logstash::indexer (
   $jarname = $logstash::config::logstash_jar
   $verbose = $logstash::config::logstash_verbose
 
-  # create the config file based on the transport we are using
-  # (this could also be extended to use different configs)
-  case  $logstash::config::logstash_transport {
-    /^redis$/: { $indexer_conf_content = template('logstash/indexer-input-redis.conf.erb',
-                                                  'logstash/indexer-filter.conf.erb',
-                                                  'logstash/indexer-output.conf.erb') }
-    /^amqp$/:  { $indexer_conf_content = template('logstash/indexer-input-amqp.conf.erb',
-                                                  'logstash/indexer-filter.conf.erb',
-                                                  'logstash/indexer-output.conf.erb') }
-    default:   { $indexer_conf_content = template('logstash/indexer-input-amqp.conf.erb',
-                                                  'logstash/indexer-filter.conf.erb',
-                                                  'logstash/indexer-output.conf.erb') }
+  if $logstash::config::indexer_template {
+    $indexer_conf_content = template($logstash::config::indexer_template)
+  }
+  else {
+    case  $logstash::config::logstash_transport {
+      /^redis$/: { $indexer_conf_content = template('logstash/indexer-input-redis.conf.erb',
+                                                    'logstash/indexer-filter.conf.erb',
+                                                    'logstash/indexer-output.conf.erb') }
+      /^amqp$/:  { $indexer_conf_content = template('logstash/indexer-input-amqp.conf.erb',
+                                                    'logstash/indexer-filter.conf.erb',
+                                                    'logstash/indexer-output.conf.erb') }
+      default:   { $indexer_conf_content = template('logstash/indexer-input-amqp.conf.erb',
+                                                    'logstash/indexer-filter.conf.erb',
+                                                    'logstash/indexer-output.conf.erb') }
+    }
   }
 
   file { "${logstash::config::logstash_etc}/indexer.conf":


### PR DESCRIPTION
I added the parameter $logstash::config::indexer_template so I could specify a custom template for the indexer.  If the parameter is not set then it defaults back to the old behavior.

Style note: I used a single parameter instead of indexer_template_input, indexer_template_filter, and indexer_template_output because it seemed like a cleaner and more flexible implementation.  If I want to use a combination of templates from puppet-logstash and private repo, I can use partial templates like below.

``` erb
<%= scope.function_template(["logstash/indexer-input-redis.conf.erb"]) %>
<%= scope.function_template(["stash/empty-filter.conf.erb"]) %>
<%= scope.function_template(["logstash/indexer-output.conf.erb"]) %>
```
