### PR TITLE
Removed fail if logstash::shipper::sharedconfig is not declared

### DIFF
--- a/manifests/shipper/sharedconfig/add_config.pp
+++ b/manifests/shipper/sharedconfig/add_config.pp
@@ -22,7 +22,4 @@ define logstash::shipper::sharedconfig::add_config($template='', $order=1) {
       content => $content
     }
   }
-  else {
-    fail('logstash::shipper::sharedconfig is required for logstash::shipper:sharedconfig::add_config')
-  }
 }


### PR DESCRIPTION
The shared configuration is used to add application specific configuration if logstash is installed. If no logstash is installed the configuration can be ignored. A faild would brick the hole puppet module.

See issue: #19
