### PR TITLE
Changed scope[] to scope.lookupvar for compatibility with puppet < Version 3

### DIFF
--- a/templates/javainitscript.erb
+++ b/templates/javainitscript.erb
@@ -75,7 +75,7 @@ function startServiceProcess {
    rm -f $pidFile
    makeFileWritable $pidFile || return 1
    makeFileWritable $serviceLogFile || return 1
-   <% if scope['logstash::config::elasticsearch_provider'] == 'embedded' and @servicename == 'logstash-indexer' %>
+   <% if scope.lookupvar('logstash::config::elasticsearch_provider') == 'embedded' and @servicename == 'logstash-indexer' %>
      # Raise the max open files when using embedded elasticsearch
      ulimit -n 32768 || return 1
    <% end %>


### PR DESCRIPTION
The scope[] command is only available in puppet version 3. scope.lookupvar is available in Version 2 and 3
